### PR TITLE
Remove ignoreIssuedAt method

### DIFF
--- a/src/main/java/UnityDwell/com/UnityDwell/config/security/JWTService.java
+++ b/src/main/java/UnityDwell/com/UnityDwell/config/security/JWTService.java
@@ -52,7 +52,6 @@ public class JWTService {
         Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) getPublicKey(jwt), null);
         JWTVerifier verifier = JWT.require(algorithm)
                 .withIssuer(tenantURI)
-                .ignoreIssuedAt() //temporary solution
                 .build();
         verifier.verify(jwtToken);
     }


### PR DESCRIPTION
Removed ignoreIssuedAt (which was added as a temporary solution for acceptExpiresAt) as token expiration check is added by default when building JWTVerifier. So none of those methods are needed.